### PR TITLE
feat(_template): added more examples to instrumentation config

### DIFF
--- a/_template/config.yml
+++ b/_template/config.yml
@@ -23,8 +23,24 @@ authors:
 # This allows you to define which instrumentation is needed for your pack
 # Any file in the instrumentation folder will automatically be picked up
 instrumentation:
+  # Example for New Relic On Host Integrations
+  # Possible values: apache, cassandra, couchbase, collectd, elasticsearch, amazon-ecs, f5, go-insights-monitoring, haproxy, hashicorp-consul, jmx, kafka, kubernetes, memcached, mongodb, mssql, mysql, nagios, nfs, nginx, oracledb, postgresql, rabbitmq, redis, snmp, unix-monitoring, varnish-cache, vmware-vsphere, vmware-tanzu, zookeeper
   - type: newrelic-infra-ohi
     name: nginx
+  # Example for New Relic APM Agent
+  # Possible values: c, golang, java, dotnet, dotnet-core, nodejs, php, python, ruby
+  - type: newrelic-apm
+    name: java
+  # Example for New Relic Cloud integration
+  # Possible values can be found on our docs:
+  # - AWS (aws): https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/
+  # - Azure (azure): https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/
+  # - Google Cloud (gcp): https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/
+  # The value of name should be the cloud provider + the name of the service in lowercase. For example: `aws-rds`, `azure-cosmosdb`, `gcp-bigquery`.
+  - type: newrelic-cloud-integration
+    name: aws-s3
+  # Example for Prometheus Exporter
+  # The url should point to a repository containing the prometheus exporter
   - type: prometheus
     url: https://github.com/nginxinc/nginx-prometheus-exporter
 


### PR DESCRIPTION
I added some more examples to the instrumentation section of the config. Specifically I added an APM example, cloud integration example, and instructions for OHI's and Prometheus exporters. 