### PR TITLE
chore: update contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,15 @@
+<!-- toc -->
+- [Contributing](#contributing)
+  - [Observability Pack Guidelines](#observability-pack-guidelines)
+  - [Feature Requests](#feature-requests)
+  - [Pull Requests](#pull-requests)
+  - [Using Conventional Commits](#using-conventional-commits)
+      - [Use `chore`](#use-chore)
+      - [Use `fix`](#use-fix)
+      - [Use `feat`](#use-feat)
+  - [Contributor License Agreement](#contributor-license-agreement)
+  - [Slack](#slack)
+<!-- tocstop -->
 
 # Contributing
 
@@ -7,7 +19,6 @@ Contributions are always welcome. Before contributing please read the
 
 Note that our [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md) applies to all platforms and venues related to this project; please follow it in all your interactions with the project and its participants.
 
----
 
 ## Observability Pack Guidelines
 
@@ -16,8 +27,6 @@ We encourage all contributors to actively engage in the creation and maintenance
 > Review the [pack template config](./_template/config.yml) file for a definition of how to create a pack.
 
 If you decide to create a new Observability Pack or review a PR please keep the following in mind.
-
-### Observability Pack Name & Descriptions
 
 | Pack Configuration  | Rule  | Limits  |Required |
 |---|---|---|---|
@@ -73,12 +82,6 @@ git commit -m "fix: typo and prop error in the code of conduct"
 ```bash
 git commit -m "feat(media): creating a video landing page"
 ```
-
-
-
-
-
-### YAML definitions
 
 ## Contributor License Agreement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,4 @@
+
 # Contributing
 
 Contributions are always welcome. Before contributing please read the
@@ -5,6 +6,29 @@ Contributions are always welcome. Before contributing please read the
 [fork](https://help.github.com/articles/fork-a-repo/) this repository, commit your changes, and [send a Pull Request](https://help.github.com/articles/using-pull-requests/).
 
 Note that our [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md) applies to all platforms and venues related to this project; please follow it in all your interactions with the project and its participants.
+
+---
+
+## Observability Pack Guidelines
+
+We encourage all contributors to actively engage in the creation and maintenance of Observability Packs. Whether you work at New Relic or use New Relic as a customer, the community is open to your expertise!
+
+> Review the [pack template config](./_template/config.yml) file for a definition of how to create a pack.
+
+If you decide to create a new Observability Pack or review a PR please keep the following in mind.
+
+### Observability Pack Name & Descriptions
+
+| Pack Configuration  | Rule  | Limits  |Required |
+|---|---|---|---|
+| `name`  | pack name should be concise and explicit  |limited to 100 characters   | Yes|
+|`description` |Descriptions should be checked for grammar and spelling errors   | limited to 1000 characters  | Yes|
+|`icon`   |.png or .jpeg format   |   | No|
+|`logo`   | .png or .jpeg format  |   |No|
+|`website`   | A valid website    |Valid URL only (https://www.newrelic.com) | No|
+|`author`   |  The creator of the pack |max 10   |Yes|
+|`instrumentation`   | Defines which instrumentation is needed|   |No   |
+|`references`   | References to other packs  ||No   |
 
 ## Feature Requests
 
@@ -49,6 +73,12 @@ git commit -m "fix: typo and prop error in the code of conduct"
 ```bash
 git commit -m "feat(media): creating a video landing page"
 ```
+
+
+
+
+
+### YAML definitions
 
 ## Contributor License Agreement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,17 +28,6 @@ We encourage all contributors to actively engage in the creation and maintenance
 
 If you decide to create a new Observability Pack or review a PR please keep the following in mind.
 
-| Pack Configuration  | Rule  | Limits  |Required |
-|---|---|---|---|
-| `name`  | pack name should be concise and explicit  |limited to 100 characters   | Yes|
-|`description` |Descriptions should be checked for grammar and spelling errors   | limited to 1000 characters  | Yes|
-|`icon`   |.png or .jpeg format   |   | No|
-|`logo`   | .png or .jpeg format  |   |No|
-|`website`   | A valid website    |Valid URL only (https://www.newrelic.com) | No|
-|`author`   |  The creator of the pack |max 10   |Yes|
-|`instrumentation`   | Defines which instrumentation is needed|   |No   |
-|`references`   | References to other packs  ||No   |
-
 ## Feature Requests
 
 Feature requests should be submitted in the [Issue tracker](../../issues), with a description of the expected behavior & use case, where they’ll remain closed until sufficient interest, [e.g. :+1: reactions](https://help.github.com/articles/about-discussions-in-issues-and-pull-requests/), has been [shown by the community](../../issues?q=label%3A%22votes+needed%22+sort%3Areactions-%2B1-desc).


### PR DESCRIPTION
This PR gives a contributor some guidelines to consider as the work to submit a new pack or review a PR on an existing pack. It's dependent on our conversation around limitations for the API