### PR TITLE
fix: update couchbase logo filename in config

### DIFF
--- a/packs/couchbase/config.yml
+++ b/packs/couchbase/config.yml
@@ -12,7 +12,7 @@ level: New Relic
 
 # Design
 icon: icon.jpeg
-logo: logo.png # When this is not set to a filepath or url, we look for logo.jpeg|jpg|png|gif?
+logo: logo.svg # When this is not set to a filepath or url, we look for logo.jpeg|jpg|png|gif?
 website: https://www.couchbase.com/
 
 # Authors of the pack


### PR DESCRIPTION
## Summary

the `logo` value in the couchbase config was previously logo.png, but the logo in the directory is actually logo.svg, so updated that value to reflect what is actually in the directory.

Resolves: https://github.com/newrelic/developer-website/issues/1389