### PR TITLE
Add doc and schema for documentation field

### DIFF
--- a/docs/config-spec.md
+++ b/docs/config-spec.md
@@ -45,10 +45,10 @@ authors: list, required
 # Instrumentation Requirements - indicates what's needed in an account
 # for a given pack (and it's components) to work.
 #
-# It's important that we're able to verify whether or not the user's 
-# environment meets the requirements for the use of a given resource. 
+# It's important that we're able to verify whether or not the user's
+# environment meets the requirements for the use of a given resource.
 instrumentation: list(object), optional
-  - type: string, optional 
+  - type: string, optional
     name: string, optional
 
 #####################
@@ -84,6 +84,13 @@ logo: string, optional
 
 # URL of website for this Observability Pack
 website: string, optional
+
+# List of docs for this Observability Pack
+documentation: list(object), optional
+  - name: string, required
+    url: string, required
+    description: string, optional
+
 ```
 
 ## Schema Validator

--- a/utils/__tests__/validate_packs.test.js
+++ b/utils/__tests__/validate_packs.test.js
@@ -28,11 +28,13 @@ const getTestFile = (schemaType) => {
         {
           name: 'fakedashboard',
           description: 'fakeDescription',
-          pages: [{
-            name: "",
-            description: "",
-            widgets: [{}]
-          }]
+          pages: [
+            {
+              name: '',
+              description: '',
+              widgets: [{}],
+            },
+          ],
         },
       ],
     },
@@ -62,7 +64,7 @@ const getTestFile = (schemaType) => {
           name: 'fakeobservabilitypack',
           description: 'fakeDescription',
           authors: ['fakeAuthor'],
-          level: 'New Relic'
+          level: 'New Relic',
         },
       ],
     },
@@ -303,6 +305,50 @@ describe('test validateFile', () => {
       const { errors } = validateFile(mainConfigTestFile);
 
       expect(errors.length).toBe(1);
+    });
+
+    test('doesnt fail for valid documentation fields', () => {
+      const mainConfigTestFile = getTestFile('main_config');
+
+      mainConfigTestFile.contents[0].documentation = [
+        {
+          name: 'Doc name',
+          url: 'https://example.com',
+          description: 'Description of doc',
+        },
+      ];
+
+      const { errors } = validateFile(mainConfigTestFile);
+
+      expect(errors.length).toBe(0);
+    });
+
+    test('detects missing documentation name field', () => {
+      const mainConfigTestFile = getTestFile('main_config');
+
+      mainConfigTestFile.contents[0].documentation = [
+        {
+          url: 'https://example.com',
+        },
+      ];
+
+      const { errors } = validateFile(mainConfigTestFile);
+
+      expect(errors.length).toBe(2);
+    });
+
+    test('detects missing documentation url field', () => {
+      const mainConfigTestFile = getTestFile('main_config');
+
+      mainConfigTestFile.contents[0].documentation = [
+        {
+          name: 'Name of doc',
+        },
+      ];
+
+      const { errors } = validateFile(mainConfigTestFile);
+
+      expect(errors.length).toBe(2);
     });
   });
 });

--- a/utils/schemas/main_config.json
+++ b/utils/schemas/main_config.json
@@ -41,7 +41,12 @@
       ],
       "icon": "icon.jpg",
       "logo": "logo.png",
-      "website": "https://www.newrelic.com"
+      "website": "https://www.newrelic.com",
+      "documentation": {
+        "name": "How to use this pack",
+        "url": "https://example.com",
+        "description": "A brief summary of what this doc entails."
+      }
     }
   ],
   "required": [
@@ -370,6 +375,77 @@
       "examples": [
         "https://www.newrelic.com"
       ]
+    },
+    "documentation": {
+      "$id": "#/properties/documentation",
+      "type:": "array",
+      "title": "The documentation schema",
+      "description": "List of documentation links for this pack.",
+      "default": [],
+      "uniqueItems": true,
+      "examples": [
+        [
+          {
+          "name": "How to use this pack",
+          "url": "https://example.com",
+          "description": "A brief summary of what this doc entails."
+          }
+        ]
+      ],
+      "items": {
+        "$id": "#/properties/documentation/items",
+        "anyOf": [
+          {
+            "$id": "#/properties/documentation/items/anyOf/0",
+            "type": "object",
+            "title": "",
+            "description": "",
+            "default": "",
+            "examples": [
+              {
+                "name": "How to use this pack",
+                "url": "https://example.com",
+                "description": "A brief summary of what this doc entails."
+              }
+            ],
+            "required": [
+              "name", "url"
+            ],
+            "properties": {
+              "name": {
+                "$id": "#/properties/documentation/items/anyOf/0/properties/name",
+                "type": "string",
+                "title": "The name schema",
+                "description": "Name or title of the documentation resource.",
+                "default": "",
+                "examples": [
+                  "How to use this pack"
+                ]
+              },
+              "url": {
+                "$id": "#/properties/documentation/items/anyOf/0/properties/url",
+                "type": "string",
+                "title": "The url schema",
+                "description": "The URL for the documentation resource.",
+                "default": "",
+                "examples": [
+                  "https://example.com"
+                ]
+              },
+              "description": {
+                "$id": "#/properties/documentation/items/anyOf/0/properties/description",
+                "type": "string",
+                "title": "The description schema",
+                "description": "Brief description / summary of this documentation resource.",
+                "default": "",
+                "examples": [
+                  "How to install, enable, and use this pack."
+                ]
+              }
+            }
+          }
+        ]
+      }
     }
   }
 }

--- a/utils/schemas/main_config.json
+++ b/utils/schemas/main_config.json
@@ -378,7 +378,7 @@
     },
     "documentation": {
       "$id": "#/properties/documentation",
-      "type:": "array",
+      "type": "array",
       "title": "The documentation schema",
       "description": "List of documentation links for this pack.",
       "default": [],
@@ -398,8 +398,8 @@
           {
             "$id": "#/properties/documentation/items/anyOf/0",
             "type": "object",
-            "title": "",
-            "description": "",
+            "title": "The first anyOf schema",
+            "description": "An explanation about the purpose of this instance.",
             "default": "",
             "examples": [
               {

--- a/utils/schemas/main_config.json
+++ b/utils/schemas/main_config.json
@@ -10,9 +10,7 @@
       "name": "Apache",
       "description": "The template pack allows you to get visibilility into the performance and available of your example service and dependencies. Use this pack together with the mock up integrations.",
       "level": "New Relic",
-      "authors": [
-        "New Relic"
-      ],
+      "authors": ["New Relic"],
       "instrumentation": [
         {
           "name": "apachi-ohi",
@@ -22,11 +20,7 @@
       "title": "Title of Pack",
       "short-description": "Short description of pack",
       "full-description": "Full description of pack",
-      "tags": [
-        "filters",
-        "for",
-        "searching"
-      ],
+      "tags": ["filters", "for", "searching"],
       "children": {
         "title": "Title of Pack",
         "description": "Description of child pack",
@@ -42,19 +36,16 @@
       "icon": "icon.jpg",
       "logo": "logo.png",
       "website": "https://www.newrelic.com",
-      "documentation": {
-        "name": "How to use this pack",
-        "url": "https://example.com",
-        "description": "A brief summary of what this doc entails."
-      }
+      "documentation": [
+        {
+          "name": "How to use this pack",
+          "url": "https://example.com",
+          "description": "A brief summary of what this doc entails."
+        }
+      ]
     }
   ],
-  "required": [
-    "name",
-    "description",
-    "level",
-    "authors"
-  ],
+  "required": ["name", "description", "level", "authors"],
   "properties": {
     "name": {
       "$id": "#/properties/name",
@@ -62,9 +53,7 @@
       "title": "The name schema",
       "description": "The overall name of the Observability Pack",
       "default": "",
-      "examples": [
-        "Apache"
-      ]
+      "examples": ["Apache"]
     },
     "description": {
       "$id": "#/properties/description",
@@ -83,15 +72,9 @@
       "type": "string",
       "title": "The level schema",
       "description": "The support level provided to this Observability Pack",
-      "enum": [
-        "New Relic",
-        "Verified",
-        "Community"
-      ],
+      "enum": ["New Relic", "Verified", "Community"],
       "default": "",
-      "examples": [
-        "New Relic"
-      ]
+      "examples": ["New Relic"]
     },
     "authors": {
       "$id": "#/properties/authors",
@@ -99,11 +82,7 @@
       "title": "The authors schema",
       "description": "The support level provided to this Observability Pack",
       "default": [],
-      "examples": [
-        [
-          "New Relic"
-        ]
-      ],
+      "examples": [["New Relic"]],
       "items": {
         "$id": "#/properties/authors/items",
         "anyOf": [
@@ -113,9 +92,7 @@
             "title": "The first anyOf schema",
             "description": "An explanation about the purpose of this instance.",
             "default": "",
-            "examples": [
-              "New Relic"
-            ]
+            "examples": ["New Relic"]
           }
         ]
       },
@@ -159,9 +136,7 @@
                 "title": "The name schema",
                 "description": "The name of the instrumentation",
                 "default": "",
-                "examples": [
-                  "apachi-ohi"
-                ]
+                "examples": ["apachi-ohi"]
               },
               "type": {
                 "$id": "#/properties/instrumentation/items/anyOf/0/properties/type",
@@ -169,9 +144,7 @@
                 "title": "The type schema",
                 "description": "The type of New Relic Product the instrumentation falls under",
                 "default": "",
-                "examples": [
-                  "type"
-                ]
+                "examples": ["type"]
               }
             }
           }
@@ -184,9 +157,7 @@
       "title": "The title schema",
       "description": "The name of the pack displayed everywhere the pack is referenced",
       "default": "",
-      "examples": [
-        "Title of Pack"
-      ]
+      "examples": ["Title of Pack"]
     },
     "summary": {
       "$id": "#/properties/short-description",
@@ -196,9 +167,7 @@
       "minLength": 0,
       "maxLength": 250,
       "default": "",
-      "examples": [
-        "Short description of pack"
-      ]
+      "examples": ["Short description of pack"]
     },
     "tags": {
       "$id": "#/properties/tags",
@@ -206,11 +175,7 @@
       "title": "The tags schema",
       "description": "Tags for filtering / searching criteria in the New Relic Platform and GraphQL API",
       "default": [],
-      "examples": [
-        [
-          "searchFilters"
-        ]
-      ],
+      "examples": [["searchFilters"]],
       "items": {
         "$id": "#/properties/tags/items",
         "anyOf": [
@@ -220,9 +185,7 @@
             "title": "The first anyOf schema",
             "description": "An explanation about the purpose of this instance.",
             "default": "",
-            "examples": [
-              "searchFilters"
-            ]
+            "examples": ["searchFilters"]
           }
         ]
       }
@@ -248,9 +211,7 @@
           "title": "The title schema",
           "description": "An explanation about the purpose of this instance.",
           "default": "",
-          "examples": [
-            "Title of Pack"
-          ]
+          "examples": ["Title of Pack"]
         },
         "description": {
           "$id": "#/properties/children/properties/description",
@@ -258,9 +219,7 @@
           "title": "The description schema",
           "description": "An explanation about the purpose of this instance.",
           "default": "",
-          "examples": [
-            "Description of child pack"
-          ]
+          "examples": ["Description of child pack"]
         },
         "screenshots": {
           "$id": "#/properties/children/properties/screenshots",
@@ -268,9 +227,7 @@
           "title": "The screenshots schema",
           "description": "An explanation about the purpose of this instance.",
           "default": "",
-          "examples": [
-            "Screenshots of child pack"
-          ]
+          "examples": ["Screenshots of child pack"]
         }
       }
     },
@@ -305,11 +262,7 @@
                 "avatar-url": "avatar-url"
               }
             ],
-            "required": [
-              "github-username",
-              "profile-url",
-              "avatar-url"
-            ],
+            "required": ["github-username", "profile-url", "avatar-url"],
             "properties": {
               "github-username": {
                 "$id": "#/properties/contributors/items/anyOf/0/properties/github-username",
@@ -317,9 +270,7 @@
                 "title": "The github-username schema",
                 "description": "An explanation about the purpose of this instance.",
                 "default": "",
-                "examples": [
-                  "username"
-                ]
+                "examples": ["username"]
               },
               "profile-url": {
                 "$id": "#/properties/contributors/items/anyOf/0/properties/profile-url",
@@ -327,9 +278,7 @@
                 "title": "The profile-url schema",
                 "description": "An explanation about the purpose of this instance.",
                 "default": "",
-                "examples": [
-                  "profiles-url"
-                ]
+                "examples": ["profiles-url"]
               },
               "avatar-url": {
                 "$id": "#/properties/contributors/items/anyOf/0/properties/avatar-url",
@@ -337,9 +286,7 @@
                 "title": "The avatar-url schema",
                 "description": "An explanation about the purpose of this instance.",
                 "default": "",
-                "examples": [
-                  "avatar-url"
-                ]
+                "examples": ["avatar-url"]
               }
             }
           }
@@ -352,9 +299,7 @@
       "title": "The icon schema",
       "description": "An explanation about the purpose of this instance.",
       "default": "",
-      "examples": [
-        "icon.jpg"
-      ]
+      "examples": ["icon.jpg"]
     },
     "logo": {
       "$id": "#/properties/logo",
@@ -362,9 +307,7 @@
       "title": "The logo schema",
       "description": "An explanation about the purpose of this instance.",
       "default": "",
-      "examples": [
-        "logo.png"
-      ]
+      "examples": ["logo.png"]
     },
     "website": {
       "$id": "#/properties/website",
@@ -372,9 +315,7 @@
       "title": "The website schema",
       "description": "An explanation about the purpose of this instance.",
       "default": "",
-      "examples": [
-        "https://www.newrelic.com"
-      ]
+      "examples": ["https://www.newrelic.com"]
     },
     "documentation": {
       "$id": "#/properties/documentation",
@@ -386,9 +327,9 @@
       "examples": [
         [
           {
-          "name": "How to use this pack",
-          "url": "https://example.com",
-          "description": "A brief summary of what this doc entails."
+            "name": "How to use this pack",
+            "url": "https://example.com",
+            "description": "A brief summary of what this doc entails."
           }
         ]
       ],
@@ -408,9 +349,7 @@
                 "description": "A brief summary of what this doc entails."
               }
             ],
-            "required": [
-              "name", "url"
-            ],
+            "required": ["name", "url"],
             "properties": {
               "name": {
                 "$id": "#/properties/documentation/items/anyOf/0/properties/name",
@@ -418,9 +357,7 @@
                 "title": "The name schema",
                 "description": "Name or title of the documentation resource.",
                 "default": "",
-                "examples": [
-                  "How to use this pack"
-                ]
+                "examples": ["How to use this pack"]
               },
               "url": {
                 "$id": "#/properties/documentation/items/anyOf/0/properties/url",
@@ -428,9 +365,7 @@
                 "title": "The url schema",
                 "description": "The URL for the documentation resource.",
                 "default": "",
-                "examples": [
-                  "https://example.com"
-                ]
+                "examples": ["https://example.com"]
               },
               "description": {
                 "$id": "#/properties/documentation/items/anyOf/0/properties/description",
@@ -438,9 +373,7 @@
                 "title": "The description schema",
                 "description": "Brief description / summary of this documentation resource.",
                 "default": "",
-                "examples": [
-                  "How to install, enable, and use this pack."
-                ]
+                "examples": ["How to install, enable, and use this pack."]
               }
             }
           }

--- a/utils/schemas/main_config.json
+++ b/utils/schemas/main_config.json
@@ -340,7 +340,7 @@
             "$id": "#/properties/documentation/items/anyOf/0",
             "type": "object",
             "title": "The first anyOf schema",
-            "description": "An explanation about the purpose of this instance.",
+            "description": "A collection of name, url, and optional description for a piece of documentation.",
             "default": "",
             "examples": [
               {

--- a/utils/validate_packs.js
+++ b/utils/validate_packs.js
@@ -85,10 +85,10 @@ const validateFile = (file) => {
     case filePath.includes('/instrumentation/synthetics/'): // validate using synthetics schema
       errors = validateAgainstSchema(file.contents[0], syntheticSchema);
       break;
-    case(filePath.includes('/instrumentation/logging/')): // validate using logging schema
+    case filePath.includes('/instrumentation/logging/'): // validate using logging schema
       errors = validateAgainstSchema(file.contents[0], loggingSchema);
       break;
-    case(filePath.includes('/instrumentation/flex/')): // validate using flex config schema. 
+    case filePath.includes('/instrumentation/flex/'): // validate using flex config schema.
       // The flex YAML is two documents, validate each of them
       errors = [
         ...validateAgainstSchema(file.contents[0], flexConfigSchema),


### PR DESCRIPTION
## Summary

Updates doc and JSON schema for forthcoming pack `documentation` field.

## Notes
* Held off on URL validation for now as there isn't a great, built-in way to do that in JSON schema. [Regex has it's pitfalls](https://json-schema.org/understanding-json-schema/reference/string.html#index-12) and [this](https://www.stephenlewis.me/notes/json-schema-url-validation/) is closest way I found, which felt like it could hit some snags.

## Related issues / PRs
https://github.com/newrelic/newrelic-observability-packs/issues/140
open-install-library-service/pull/56


