### PR TITLE
feat: add initial install plans

### DIFF
--- a/docs/config-spec.md
+++ b/docs/config-spec.md
@@ -41,8 +41,12 @@ level: enum, required # One of [ New Relic, Verified, Community ]
 # List of contributors for this Observability Pack
 authors: list, required
 
+# DEPRECATED: Use keywords instead
 # Tags for filtering / searching criteria
 tags: list(string), optional
+
+# Keywords for filtering / searching criteria
+keywords: list(string), optional
 
 # path to icon for this Observability Pack
 # Not currently used
@@ -54,14 +58,9 @@ logo: string, optional
 # URL of website for this Observability Pack
 website: string, optional
 
-# Instrumentation Requirements - indicates what's needed in an account
-# for a given pack (and it's components) to work.
-#
-# It's important that we're able to verify whether or not the user's
-# environment meets the requirements for the use of a given resource.
-instrumentation: list(object), optional
-  - type: string, optional
-    name: string, optional
+# Reference to install plans located under /install directory
+# Allows us to construct reusable "install plans" and just use their ID in the quickstart config
+installPlans: list(string), optional
 
 # Displaying related child packs
 # Future feature

--- a/docs/example-schemas/config.json
+++ b/docs/example-schemas/config.json
@@ -5,16 +5,14 @@
   "authors": [
     "New Relic"
   ],
-  "instrumentation": [
-    {
-      "name": "apachi-ohi",
-      "type": "type"
-    }
+  "installPlans": [
+    "id-1",
+    "id-2"
   ],
   "title": "Title of Pack",
   "short-description": "Short description of pack",
   "full-description": "Full description of pack",
-  "tags": [
+  "keywords": [
     "filters",
     "for",
     "searching"

--- a/docs/install-spec.md
+++ b/docs/install-spec.md
@@ -1,0 +1,51 @@
+# Install Plan File Schema
+
+Install plans define how to install agents, integrations, and instrumentation for a Quickstart. They’re defined once in the /install directory and then are referencable in Quickstart’s config.yml by using the install-plan field.
+
+## Filename format
+
+Install Plans are placed under `install/<plan_type>/install.yml` and can be nested.
+
+For eample:
+
+* `install/apm/java/install.yml`
+* `install/infrastructure/infra-agent-standard/install.yml`
+
+## Schema Definition
+
+```yaml
+id: string, required
+
+# where the install occurs
+# set up context/expectation for what the user is going to need to perform this installation
+target: object, required
+  type: enum, required                # one of [ agent, integration, on-host-integration, pixie, NPM (net perf monitoring), unknown (special case for guided-install) ]
+  destination: enum, required         # one of [ application, host, kubernetes, cloud, unknown (special-case for guided-install) ]
+  os: list(enum), optional            # one of [ linux, darwin, windows ]
+  context: string(markdown), optional # For display in the right-sidebar
+
+# primary install directive
+install: object, required
+  mode: enum, required            # one of: [ guidedInstall, targetedInstall, nerdlet, link ] (eventually: documentation, other fields (in-product help XP?) )
+  destination: object, required   # required input for the mode to function
+    recipeName: string, optional  # valid for mode: [ guidedInstall, targetedInstall ]
+    nerdletId: id, optional       # only valid for mode: nerdlet, ex: nerdpackId.nerdletId
+    url: string, optional         # valid for mode: link
+
+# secondary install directive
+# Note: even though this object is the same shape as `install`, we're choosing
+# to make it an explicit field, vs alternatives like having a single `install`
+# field that's a list(object) type (as that would be implicit behavior, and
+# I'd rather avoid that)
+fallback: object, optional
+  mode: enum, required            # one of: [ guidedInstall, targetedInstall, nerdlet, link ] (eventually: documentation, other fields (in-product help XP?) )
+  destination: object, required   # required input for the mode to function
+    recipeName: string, optional  # valid for mode: [ guidedInstall, targetedInstall ]
+    nerdletId: id, optional       # only valid for mode: nerdlet, ex: nerdpackId.nerdletId
+    url: string, optional         # valid for mode: link
+
+# Add more data fields
+# These fields are displayed in the install plan 
+title: string, optional       # Display-only field for install plan
+description: string, optional # Display-only field for install plan
+```

--- a/docs/install-spec.md
+++ b/docs/install-spec.md
@@ -1,6 +1,6 @@
 # Install Plan File Schema
 
-Install plans define how to install agents, integrations, and instrumentation for a Quickstart. They’re defined once in the /install directory and then are referencable in Quickstart’s config.yml by using the install-plan field.
+Install plans define how to install agents, integrations, and instrumentation for a quickstart. They’re defined once in the /install directory and then are referencable in the quickstart’s config.yml by using the install-plan field.
 
 ## Filename format
 

--- a/install/apm/python/install.yml
+++ b/install/apm/python/install.yml
@@ -1,0 +1,17 @@
+id: setup-python-agent
+title: Python Agent Installation
+description: Start monitoring the performance of a Python application or service by installing the New Relic Ruby agent.
+
+target:
+  type: agent
+  destination: application
+
+install:
+  mode: nerdlet
+  destination:
+    nerdletId: setup-nerdlets.setup-python-integration
+
+fallback:
+  mode: link
+  destination:
+    url: https://docs.newrelic.com/docs/agents/python-agent/installation/standard-python-agent-install/#install

--- a/install/apm/ruby/install.yml
+++ b/install/apm/ruby/install.yml
@@ -1,0 +1,17 @@
+id: setup-ruby-agent
+title: Ruby Agent Installation
+description: Start monitoring the performance of a Ruby application or service by installing the New Relic Ruby agent.
+
+target:
+  type: agent
+  destination: application
+
+install:
+  mode: nerdlet
+  destination:
+    nerdletId: setup-nerdlets.setup-ruby-integration
+
+fallback:
+  mode: link
+  destination:
+    url: https://docs.newrelic.com/docs/agents/ruby-agent/getting-started/introduction-new-relic-ruby/#install

--- a/install/infrastructure/infra-agent-standard/install.yml
+++ b/install/infrastructure/infra-agent-standard/install.yml
@@ -1,0 +1,18 @@
+id: infra-agent-standard
+title: Infrastructure Agent Install
+description: |
+  New Relic's infrastructure monitoring agent is a lightweight executable file that collects data about your hosts. It also forwards data from infrastructure integrations to New Relic, as well as log data for log analytics.
+
+target:
+  type: agent
+  destination: host
+
+install:
+  mode: targetedInstall
+  destination:
+    recipeName: infrastructure-agent-installer
+
+fallback:
+  mode: link
+  destination:
+    url: https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux/#manual-install

--- a/install/infrastructure/infra-agent-targeted/install.yml
+++ b/install/infrastructure/infra-agent-targeted/install.yml
@@ -1,0 +1,22 @@
+id: infra-agent-targeted
+title: Infrastructure Agent Install
+description: |
+  New Relic's infrastructure monitoring agent is a lightweight executable file that collects data about your hosts. It also forwards data from infrastructure integrations to New Relic, as well as log data for log analytics.
+
+target:
+  type: agent
+  destination: host
+  os:
+    - darwin
+    - linux
+    - windows
+
+install:
+  mode: targetedInstall
+  destination:
+    recipeName: infrastructure-agent-installer
+
+fallback:
+  mode: link
+  destination:
+    url: https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux/#manual-install

--- a/install/on-host-integration/mysql/install.yml
+++ b/install/on-host-integration/mysql/install.yml
@@ -1,0 +1,22 @@
+id: mysql-integration
+title: MySQL Open Source Integration
+description: |
+  Our MySQL integration collects and sends inventory and metrics from your MySQL database to our platform, where you can see the health of your database server and analyze metric data so that you can easily find the source of any problems.
+
+target:
+  type: on-host-integration
+  destination: host
+  context: |-
+    To capture data from the MySQL integration, you need a MySql user with replication and select privileges. 
+
+    More information regarding the prerequisites can be found at [https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/mysql-monitoring-integration/#req](https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/mysql-monitoring-integration/#req)
+
+install:
+  mode: targetedInstall
+  destination:
+    recipeName: mysql-open-source-integration
+
+fallback:
+  mode: link
+  destination:
+    url: https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/mysql-monitoring-integration/

--- a/packs/infrastructure/config.yml
+++ b/packs/infrastructure/config.yml
@@ -15,9 +15,5 @@ authors:
   - New Relic
   - Darren Doyle
 
-# Instrumentation (optional)
-# This allows you to define which instrumentation is needed for your pack
-# Any file in the instrumentation folder will automatically be picked up
-instrumentation:
-  - type: newrelic-agent
-    name: infrastructure
+installPlans:
+  - infra-agent-standard

--- a/utils/schemas/install_config.json
+++ b/utils/schemas/install_config.json
@@ -1,0 +1,353 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "install_config.json",
+  "type": "object",
+  "title": "The root schema",
+  "description": "The root schema comprises the entire JSON document.",
+  "default": {},
+  "examples": [
+    {
+      "id": "infra-agent-standard",
+      "title": "Infrastructure Agent Install",
+      "description": "New Relic's infrastructure monitoring agent is a lightweight executable file that collects data about your hosts. It also forwards data from infrastructure integrations to New Relic, as well as log data for log analytics.",
+      "target": {
+        "type": "agent",
+        "destination": "host",
+        "os": [
+          "darwin",
+          "linux",
+          "windows"
+        ],
+        "context": "markdown content"
+      },
+      "install": {
+        "mode": "targetedInstall",
+        "destination": {
+          "recipeName": "infrastructure-agent-installer",
+          "nerdletId": "setup-nerdlets.setup-python-integration",
+          "url": "https://docs.newrelic.com/docs/agents/python-agent/installation/standard-python-agent-install/#install"
+        }
+      },
+      "fallback": {
+        "mode": "targetedInstall",
+        "destination": {
+          "recipeName": "infrastructure-agent-installer",
+          "nerdletId": "setup-nerdlets.setup-python-integration",
+          "url": "https://docs.newrelic.com/docs/agents/python-agent/installation/standard-python-agent-install/#install"
+        }
+      }
+    }
+  ],
+  "required": [
+    "id",
+    "target",
+    "install"
+  ],
+  "properties": {
+    "id": {
+      "$id": "#/properties/id",
+      "type": "string",
+      "title": "The id schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": "",
+      "examples": [
+        "infra-agent-standard"
+      ]
+    },
+    "title": {
+      "$id": "#/properties/title",
+      "type": "string",
+      "title": "The title schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": "",
+      "examples": [
+        "Infrastructure Agent Install"
+      ]
+    },
+    "description": {
+      "$id": "#/properties/description",
+      "type": "string",
+      "title": "The description schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": "",
+      "examples": [
+        "New Relic's infrastructure monitoring agent is a lightweight executable file that collects data about your hosts. It also forwards data from infrastructure integrations to New Relic, as well as log data for log analytics."
+      ]
+    },
+    "target": {
+      "$id": "#/properties/target",
+      "type": "object",
+      "title": "The target schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": {},
+      "examples": [
+        {
+          "type": "agent",
+          "destination": "host",
+          "os": [
+            "darwin",
+            "linux",
+            "windows"
+          ],
+          "context": "markdown content"
+        }
+      ],
+      "required": [
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "type": {
+          "$id": "#/properties/target/properties/type",
+          "type": "string",
+          "title": "The type schema",
+          "description": "An explanation about the purpose of this instance.",
+          "enum": [
+            "agent",
+            "integration",
+            "on-host-integration",
+            "pixie",
+            "unknown"
+          ],
+          "default": "",
+          "examples": [
+            "agent"
+          ]
+        },
+        "destination": {
+          "$id": "#/properties/target/properties/destination",
+          "type": "string",
+          "title": "The destination schema",
+          "description": "An explanation about the purpose of this instance.",
+          "enum": [
+            "application",
+            "cloud",
+            "host",
+            "kubernetes",
+            "unknown"
+          ],
+          "default": "",
+          "examples": [
+            "host"
+          ]
+        },
+        "os": {
+          "$id": "#/properties/target/properties/os",
+          "type": "array",
+          "title": "The os schema",
+          "description": "An explanation about the purpose of this instance.",
+          "default": [],
+          "examples": [
+            [
+              "darwin",
+              "linux"
+            ]
+          ],
+          "items": {
+            "$id": "#/properties/target/properties/os/items",
+            "anyOf": [
+              {
+                "$id": "#/properties/target/properties/os/items/anyOf/0",
+                "type": "string",
+                "title": "The first anyOf schema",
+                "description": "An explanation about the purpose of this instance.",
+                "enum": [
+                  "darwin",
+                  "linux",
+                  "windows"
+                ],
+                "default": "",
+                "examples": [
+                  "darwin",
+                  "linux"
+                ]
+              }
+            ]
+          }
+        },
+        "context": {
+          "$id": "#/properties/target/properties/context",
+          "type": "string",
+          "title": "The context schema",
+          "description": "An explanation about the purpose of this instance.",
+          "default": "",
+          "examples": [
+            "markdown content"
+          ]
+        }
+      }
+    },
+    "install": {
+      "$id": "#/properties/install",
+      "type": "object",
+      "title": "The install schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": {},
+      "examples": [
+        {
+          "mode": "targetedInstall",
+          "destination": {
+            "recipeName": "infrastructure-agent-installer",
+            "nerdletId": "setup-nerdlets.setup-python-integration",
+            "url": "https://docs.newrelic.com/docs/agents/python-agent/installation/standard-python-agent-install/#install"
+          }
+        }
+      ],
+      "required": [
+        "mode",
+        "destination"
+      ],
+      "properties": {
+        "mode": {
+          "$id": "#/properties/install/properties/mode",
+          "type": "string",
+          "title": "The mode schema",
+          "description": "An explanation about the purpose of this instance.",
+          "enum": [
+            "guidedInstall",
+            "targetedInstall",
+            "nerdlet",
+            "link"
+          ],
+          "default": "",
+          "examples": [
+            "targetedInstall"
+          ]
+        },
+        "destination": {
+          "$id": "#/properties/install/properties/destination",
+          "type": "object",
+          "title": "The destination schema",
+          "description": "An explanation about the purpose of this instance.",
+          "default": {},
+          "examples": [
+            {
+              "recipeName": "infrastructure-agent-installer",
+              "nerdletId": "setup-nerdlets.setup-python-integration",
+              "url": "https://docs.newrelic.com/docs/agents/python-agent/installation/standard-python-agent-install/#install"
+            }
+          ],
+          "required": [],
+          "properties": {
+            "recipeName": {
+              "$id": "#/properties/install/properties/destination/properties/recipeName",
+              "type": "string",
+              "title": "The recipeName schema",
+              "description": "An explanation about the purpose of this instance.",
+              "default": "",
+              "examples": [
+                "infrastructure-agent-installer"
+              ]
+            },
+            "nerdletId": {
+              "$id": "#/properties/install/properties/destination/properties/nerdletId",
+              "type": "string",
+              "title": "The nerdletId schema",
+              "description": "An explanation about the purpose of this instance.",
+              "default": "",
+              "examples": [
+                "setup-nerdlets.setup-python-integration"
+              ]
+            },
+            "url": {
+              "$id": "#/properties/install/properties/destination/properties/url",
+              "type": "string",
+              "title": "The url schema",
+              "description": "An explanation about the purpose of this instance.",
+              "default": "",
+              "examples": [
+                "https://docs.newrelic.com/docs/agents/python-agent/installation/standard-python-agent-install/#install"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "fallback": {
+      "$id": "#/properties/fallback",
+      "type": "object",
+      "title": "The fallback schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": {},
+      "examples": [
+        {
+          "mode": "targetedInstall",
+          "destination": {
+            "recipeName": "infrastructure-agent-installer",
+            "nerdletId": "setup-nerdlets.setup-python-integration",
+            "url": "https://docs.newrelic.com/docs/agents/python-agent/installation/standard-python-agent-install/#install"
+          }
+        }
+      ],
+      "required": [
+        "mode",
+        "destination"
+      ],
+      "properties": {
+        "mode": {
+          "$id": "#/properties/fallback/properties/mode",
+          "type": "string",
+          "title": "The mode schema",
+          "description": "An explanation about the purpose of this instance.",
+          "enum": [
+            "guidedInstall",
+            "targetedInstall",
+            "nerdlet",
+            "link"
+          ],
+          "default": "",
+          "examples": [
+            "targetedInstall"
+          ]
+        },
+        "destination": {
+          "$id": "#/properties/fallback/properties/destination",
+          "type": "object",
+          "title": "The destination schema",
+          "description": "An explanation about the purpose of this instance.",
+          "default": {},
+          "examples": [
+            {
+              "recipeName": "infrastructure-agent-installer",
+              "nerdletId": "setup-nerdlets.setup-python-integration",
+              "url": "https://docs.newrelic.com/docs/agents/python-agent/installation/standard-python-agent-install/#install"
+            }
+          ],
+          "required": [],
+          "properties": {
+            "recipeName": {
+              "$id": "#/properties/fallback/properties/destination/properties/recipeName",
+              "type": "string",
+              "title": "The recipeName schema",
+              "description": "An explanation about the purpose of this instance.",
+              "default": "",
+              "examples": [
+                "infrastructure-agent-installer"
+              ]
+            },
+            "nerdletId": {
+              "$id": "#/properties/fallback/properties/destination/properties/nerdletId",
+              "type": "string",
+              "title": "The nerdletId schema",
+              "description": "An explanation about the purpose of this instance.",
+              "default": "",
+              "examples": [
+                "setup-nerdlets.setup-python-integration"
+              ]
+            },
+            "url": {
+              "$id": "#/properties/fallback/properties/destination/properties/url",
+              "type": "string",
+              "title": "The url schema",
+              "description": "An explanation about the purpose of this instance.",
+              "default": "",
+              "examples": [
+                "https://docs.newrelic.com/docs/agents/python-agent/installation/standard-python-agent-install/#install"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/utils/schemas/main_config.json
+++ b/utils/schemas/main_config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Quickstart Configuration",
-  "description": "A minimal schema definition for Quickstarts",
+  "title": "quickstart configuration",
+  "description": "A minimal schema definition for quickstarts",
   "type": "object",
   "$id": "http://example.com/example.json",
   "default": {},
@@ -49,7 +49,7 @@
       "$id": "#/properties/name",
       "type": "string",
       "title": "The name schema",
-      "description": "The overall name of the Quickstart",
+      "description": "The overall name of the quickstart",
       "default": "",
       "examples": ["Apache"]
     },
@@ -57,7 +57,7 @@
       "$id": "#/properties/description",
       "type": "string",
       "title": "The description schema",
-      "description": "A long form description for this Quickstart",
+      "description": "A long form description for this quickstart",
       "minLength": 0,
       "maxLength": 2000,
       "default": "",
@@ -69,7 +69,7 @@
       "$id": "#/properties/level",
       "type": "string",
       "title": "The level schema",
-      "description": "The support level provided to this Quickstart",
+      "description": "The support level provided to this quickstart",
       "enum": ["New Relic", "Verified", "Community"],
       "default": "",
       "examples": ["New Relic"]
@@ -78,7 +78,7 @@
       "$id": "#/properties/authors",
       "type": "array",
       "title": "The authors schema",
-      "description": "The support level provided to this Quickstart",
+      "description": "The support level provided to this quickstart",
       "default": [],
       "examples": [["New Relic"]],
       "items": {

--- a/utils/schemas/main_config.json
+++ b/utils/schemas/main_config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Observability Pack Configuration",
-  "description": "A minimal schema definition for Observability Packs",
+  "title": "Quickstart Configuration",
+  "description": "A minimal schema definition for Quickstarts",
   "type": "object",
   "$id": "http://example.com/example.json",
   "default": {},
@@ -11,16 +11,14 @@
       "description": "The template pack allows you to get visibilility into the performance and available of your example service and dependencies. Use this pack together with the mock up integrations.",
       "level": "New Relic",
       "authors": ["New Relic"],
-      "instrumentation": [
-        {
-          "name": "apachi-ohi",
-          "type": "type"
-        }
+      "installPlans": [
+        "id-1",
+        "id-2"
       ],
       "title": "Title of Pack",
       "short-description": "Short description of pack",
       "full-description": "Full description of pack",
-      "tags": ["filters", "for", "searching"],
+      "keywords": ["filters", "for", "searching"],
       "children": {
         "title": "Title of Pack",
         "description": "Description of child pack",
@@ -51,7 +49,7 @@
       "$id": "#/properties/name",
       "type": "string",
       "title": "The name schema",
-      "description": "The overall name of the Observability Pack",
+      "description": "The overall name of the Quickstart",
       "default": "",
       "examples": ["Apache"]
     },
@@ -59,7 +57,7 @@
       "$id": "#/properties/description",
       "type": "string",
       "title": "The description schema",
-      "description": "A long form description for this Observability Pack",
+      "description": "A long form description for this Quickstart",
       "minLength": 0,
       "maxLength": 2000,
       "default": "",
@@ -71,7 +69,7 @@
       "$id": "#/properties/level",
       "type": "string",
       "title": "The level schema",
-      "description": "The support level provided to this Observability Pack",
+      "description": "The support level provided to this Quickstart",
       "enum": ["New Relic", "Verified", "Community"],
       "default": "",
       "examples": ["New Relic"]
@@ -80,7 +78,7 @@
       "$id": "#/properties/authors",
       "type": "array",
       "title": "The authors schema",
-      "description": "The support level provided to this Observability Pack",
+      "description": "The support level provided to this Quickstart",
       "default": [],
       "examples": [["New Relic"]],
       "items": {
@@ -99,54 +97,31 @@
       "minItems": 1,
       "uniqueItems": true
     },
-    "instrumentation": {
-      "$id": "#/properties/instrumentation",
+    "installPlans": {
+      "$id": "#/properties/installPlans",
       "type": "array",
-      "title": "The instrumentation schema",
-      "description": "An explanation about the purpose of this instance.",
+      "title": "The installPlans schema",
+      "description": "Reference to install plans located under /install directory",
       "default": [],
       "examples": [
         [
-          {
-            "name": "apachi-ohi",
-            "type": "type"
-          }
+          "id-1",
+          "id-2"
         ]
       ],
       "items": {
-        "$id": "#/properties/instrumentation/items",
+        "$id": "#/properties/installPlans/items",
         "anyOf": [
           {
-            "$id": "#/properties/instrumentation/items/anyOf/0",
-            "type": "object",
+            "$id": "#/properties/installPlans/items/anyOf/0",
+            "type": "string",
             "title": "The first anyOf schema",
             "description": "An explanation about the purpose of this instance.",
-            "default": {},
+            "default": "",
             "examples": [
-              {
-                "name": "apachi-ohi",
-                "type": "type"
-              }
-            ],
-            "required": [],
-            "properties": {
-              "name": {
-                "$id": "#/properties/instrumentation/items/anyOf/0/properties/name",
-                "type": "string",
-                "title": "The name schema",
-                "description": "The name of the instrumentation",
-                "default": "",
-                "examples": ["apachi-ohi"]
-              },
-              "type": {
-                "$id": "#/properties/instrumentation/items/anyOf/0/properties/type",
-                "type": "string",
-                "title": "The type schema",
-                "description": "The type of New Relic Product the instrumentation falls under",
-                "default": "",
-                "examples": ["type"]
-              }
-            }
+              "id-1",
+              "id-2"
+            ]
           }
         ]
       }
@@ -169,18 +144,18 @@
       "default": "",
       "examples": ["Short description of pack"]
     },
-    "tags": {
-      "$id": "#/properties/tags",
+    "keywords": {
+      "$id": "#/properties/keywords",
       "type": "array",
-      "title": "The tags schema",
-      "description": "Tags for filtering / searching criteria in the New Relic Platform and GraphQL API",
+      "title": "The keywords schema",
+      "description": "keywords for filtering / searching criteria in the New Relic Platform and GraphQL API",
       "default": [],
       "examples": [["searchFilters"]],
       "items": {
-        "$id": "#/properties/tags/items",
+        "$id": "#/properties/keywords/items",
         "anyOf": [
           {
-            "$id": "#/properties/tags/items/anyOf/0",
+            "$id": "#/properties/keywords/items/anyOf/0",
             "type": "string",
             "title": "The first anyOf schema",
             "description": "An explanation about the purpose of this instance.",

--- a/utils/schemas/main_config.json
+++ b/utils/schemas/main_config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "quickstart configuration",
+  "title": "Quickstarts configuration",
   "description": "A minimal schema definition for quickstarts",
   "type": "object",
   "$id": "http://example.com/example.json",

--- a/utils/validate_packs.js
+++ b/utils/validate_packs.js
@@ -13,6 +13,7 @@ const alertSchema = require('./schemas/alert_config.json');
 const dashboardSchema = require('./schemas/dashboard_config.json');
 const flexConfigSchema = require('./schemas/flex_config.json');
 const flexIntegrationsSchema = require('./schemas/flex_integrations.json');
+const installSchema = require('./schemas/install_config.json');
 const syntheticSchema = require('./schemas/synthetic_config.json');
 const loggingSchema = require('./schemas/logging_config.json');
 
@@ -82,6 +83,9 @@ const validateFile = (file) => {
     case filePath.includes('/dashboards/'): // validate using dashboard schema
       errors = validateAgainstSchema(file.contents[0], dashboardSchema);
       break;
+    case filePath.includes('/install/'): // validate using install schema
+      errors = validateAgainstSchema(file.contents[0], installSchema);
+      break;
     case filePath.includes('/instrumentation/synthetics/'): // validate using synthetics schema
       errors = validateAgainstSchema(file.contents[0], syntheticSchema);
       break;
@@ -117,6 +121,7 @@ const getPackFilePaths = (basePath) => {
   const yamlFilePaths = [
     ...glob.sync(path.resolve(basePath, '../packs/**/*.yaml'), options),
     ...glob.sync(path.resolve(basePath, '../packs/**/*.yml'), options),
+    ...glob.sync(path.resolve(basePath, '../install/**/*.yml'), options),
   ];
 
   const jsonFilePaths = glob.sync(


### PR DESCRIPTION
## Summary

Adds schema docs and validation utils for install plans. Also includes an initial set of install plans so we can build out support in the API.

Includes some minor updates to the main_config validation to bring it in line with the API schema.