### PR TITLE
improve validation output (for null description of dashboard)

### DIFF
--- a/utils/__tests__/validate_packs.test.js
+++ b/utils/__tests__/validate_packs.test.js
@@ -182,6 +182,16 @@ describe('test validateFile', () => {
 
       expect(errors.length).toBe(1);
     });
+
+    test('ensure error output is correct for null description', () => {
+      const dashboardTestFile = getTestFile('dashboard');
+      dashboardTestFile.contents[0].description = null;
+
+      const { errors } = validateFile(dashboardTestFile);
+
+      expect(errors.length).toBe(1);
+      expect(errors[0].message).toBe("'/description' must be string");
+    });
   });
 
   describe('flex validation', () => {

--- a/utils/schemas/dashboard_config.json
+++ b/utils/schemas/dashboard_config.json
@@ -27,12 +27,7 @@
       "default": "",
       "examples": [
         ""
-      ],
-      "not": {
-        "enum": [
-          null
-        ]
-      }
+      ]
     },
     "pages": {
       "$id": "#/properties/pages",

--- a/utils/validate_packs.js
+++ b/utils/validate_packs.js
@@ -38,11 +38,18 @@ const convertErrors = (ajvErrors) => {
           e.params.allowedValues
         )}`;
         return { message };
-      case e.keyword === 'required' && e.instancePath != '':
+      case e.keyword === 'required':
+        message =
+          e.instancePath === ''
+            ? `${e.message}`
+            : `'${e.instancePath}' ${e.message}`;
+        return { message };
+      case e.instancePath !== '':
         message = `'${e.instancePath}' ${e.message}`;
         return { message };
       default:
-        return { message: e.message };
+        message = `'${e.schemaPath}' ${e.message}`;
+        return { message };
     }
   });
 


### PR DESCRIPTION
## Summary

* maintain previous functionality, but add in new functionality to add
instancePath & schemaPath to messages by default. This context will hopefully
point users to specific problematic fields and checks.
* removed redundant condition in schema json.

## Examples

Previous output:
```sh
Error: packs/mlops/algorithmia/dashboards/algorithmia.json
	 must be string
	 must NOT be valid
```

Now:
```sh
Error: packs/mlops/algorithmia/dashboards/algorithmia.json
	 '/description' must be string
```

## Links
Resolves: #324