### PR TITLE
chore: update documentation to reference quickstarts

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 ## Summary
 
 A concise description of the changes being introduced.
-If this is a new Observability Pack, please provide a description of its use cases and a list of the Pack's components.
+If this is a new quickstart, please provide a description of its use cases and a list of the quickstart's components.
 
 ### Screenshots
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,24 +101,24 @@ Alerts
 
 We encourage all contributors to actively engage in the creation and maintenance of quickstarts. Whether you work at New Relic or use New Relic as a customer, the community is open to your expertise!
 
-- `Step 1`: Review the [quickstart Template Config](./_template/config.yml) for a definition of how to create a pack.
-- `Step 2`: Review the [documentation](https://github.com/newrelic/newrelic-observability-packs/blob/main/docs) for structure and limits you need to consider.
+- `Step 1`: Review the [quickstart Template Config](./_template/config.yml) for a definition of how to create a quickstart.
+- `Step 2`: Review the [documentation](https://github.com/newrelic/newrelic-quickstarts/blob/main/docs) for structure and limits you need to consider.
 - `Step 3`: Create your quickstart!
 - `Step 4`: Submit a PR!
 - `Step 5`: resolve feedback from code reviews.
 - `Step 6`: after approval, merge your PR.
 
 When creating a new quickstart or reviewing a PR please keep the following in mind, and refer to the
-[quickstart validation workflow](https://github.com/newrelic/newrelic-observability-packs/blob/main/.github/workflows/validate_packs.yml) for current validations.
+[quickstart validation workflow](https://github.com/newrelic/newrelic-quickstarts/blob/main/.github/workflows/validate_quickstarts.yml) for current validations.
 
 ### Quick start best practices
 
-Before getting started, review the [documentation](https://github.com/newrelic/newrelic-observability-packs/blob/main/docs)
+Before getting started, review the [documentation](https://github.com/newrelic/newrelic-quickstarts/blob/main/docs)
 for quickstart structure and limits you need to consider.
 
 #### InstallPlans
 
-> See the [docs](https://github.com/newrelic/newrelic-observability-packs/blob/main/docs/main_config.md#installPlans) for more details on `installPlans`.
+> See the [docs](https://github.com/newrelic/newrelic-quickstarts/blob/main/docs/main_config.md#installPlans) for more details on `installPlans`.
 
 - The Ordering of `installPlans` is important as it sets the order of installation in the guided install flow for a user.
 - Every quick start that should be "installable" needs a `documentation URL` and an `installPlan` configuration if you want use the guided install flow.
@@ -126,7 +126,7 @@ for quickstart structure and limits you need to consider.
 #### Summary & descriptions
 
 
-> See the [docs](https://github.com/newrelic/newrelic-observability-packs/blob/main/docs/main_config.md#description) for more details on `description` and `summary`.
+> See the [docs](https://github.com/newrelic/newrelic-quickstarts/blob/main/docs/main_config.md#description) for more details on `description` and `summary`.
 
 - Use the proper YAML formatting `|` for URL `description` and `summary`.
 - Please review the [YAML cheat sheet](https://lzone.de/cheat-sheet/YAML) for more details.
@@ -142,7 +142,7 @@ summary: |
 
 #### Documentation
 
-> See the [docs](https://github.com/newrelic/newrelic-observability-packs/blob/main/docs/main_config.md#documentation) for more details on `documentation`
+> See the [docs](https://github.com/newrelic/newrelic-quickstarts/blob/main/docs/main_config.md#documentation) for more details on `documentation`
 
 - The first `documentation URL` listed in the documentation configuration should be the primary doc reference.
 - The see installation docs buttons will always link to the primary `documentation URL`.
@@ -162,7 +162,7 @@ documentation:
 
 #### Levels
 
-> See the [docs](https://github.com/newrelic/newrelic-observability-packs/blob/main/docs/main_config.md#level) for more details on `levels`
+> See the [docs](https://github.com/newrelic/newrelic-quickstarts/blob/main/docs/main_config.md#level) for more details on `levels`
 
 - All quickstarts will be set to `Community` level by default unless specified differently by the `Author`.
 - Levels can only be modified by New Relic employees.
@@ -170,7 +170,7 @@ documentation:
 
 #### Dashboard images (screenshots)
 
-> See the [docs](https://github.com/newrelic/newrelic-observability-packs/blob/main/docs/dashboard_config.md#pages_items_anyOf_i0_additionalProperties) for more details `dashboards`
+> See the [docs](https://github.com/newrelic/newrelic-quickstarts/blob/main/docs/dashboard_config.md#pages_items_anyOf_i0_additionalProperties) for more details `dashboards`
 
 - Dashboard images are `optional` but highly recommended to preview the visual functionality of a dashboard.
 - file name should be `quickstart_name01`, `quickstart_name02`, etc
@@ -184,7 +184,7 @@ documentation:
 
 #### Logos
 
-> See the [docs](https://github.com/newrelic/newrelic-observability-packs/blob/main/docs/main_config.md#logo) for more details `logos`
+> See the [docs](https://github.com/newrelic/newrelic-quickstarts/blob/main/docs/main_config.md#logo) for more details `logos`
 
 - Logo files should go in the root quickstart directory, `/quickstarts_name01`
 - Logos are `optional` but highly recommended to call attention to your quickstart.
@@ -195,7 +195,7 @@ documentation:
 
 ### Icons
 
-> See the [docs](https://github.com/newrelic/newrelic-observability-packs/blob/main/docs/main_config.md#icon) for more details on `icon`
+> See the [docs](https://github.com/newrelic/newrelic-quickstarts/blob/main/docs/main_config.md#icon) for more details on `icon`
 
 - Icons are `optional` and not currently used in the UI.
 - `.png` or `.jpeg` or `.svg` format
@@ -203,7 +203,7 @@ documentation:
 
 ### Keywords
 
-> See the [docs](https://github.com/newrelic/newrelic-observability-packs/blob/main/docs/main_config.md#keywords) for more details on `keywords`
+> See the [docs](https://github.com/newrelic/newrelic-quickstarts/blob/main/docs/main_config.md#keywords) for more details on `keywords`
 
 When adding keywords to a quickstart the following format should be used.  Keywords are used in UI navigation, filters and labels within
 the New Relic One I/O Catalog and the External I/O Catalog.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Community Project header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Project.png)](https://opensource.newrelic.com/oss-category/#community-project)
 
+**NOTE:** We recently changed this repository from `newrelic-observability-packs` to `newrelic-quickstarts` to better align with the project goals. If any of your services are reliant on this repo they will need to be checked and altered.
+
 # New Relic One quickstarts
 
 > 🧪 This project is currently in an `ALPHA` state 🧪
@@ -39,7 +41,7 @@ Contribute your own quickstart to the New Relic One catalog by following the ste
 
 2. [Clone your own repository to your local machine](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository)
 
-3. Copy the `_template` directory and its content to a new directory within the `packs` folder. Choose a name which identifies the purpose of your quickstart, such as `rabbitmq`, `apm-errors`, `sre`, or `aws-s3`
+3. Copy the `_template` directory and its content to a new directory within the `quickstarts` folder. Choose a name which identifies the purpose of your quickstart, such as `rabbitmq`, `apm-errors`, `sre`, or `aws-s3`
 
 4. In your new directory, you'll find the following folders: `dashboards` and `alerts` . Each folder contains a template or template directories that you can use to create entities for your quickstart.
 
@@ -69,7 +71,7 @@ Contribute your own quickstart to the New Relic One catalog by following the ste
     git push
     ```
 
-8. [Create a pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) in the [parent repository](https://github.com/newrelic/newrelic-observability-packs/compare?expand=1).
+8. [Create a pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) in the [parent repository](https://github.com/newrelic/newrelic-quickstarts/compare?expand=1).
 
 9. Submit and wait for review. Please be available to resolve review feedback in a timely manner.
 
@@ -79,7 +81,7 @@ Contribute your own quickstart to the New Relic One catalog by following the ste
 
 > WARNING: The importer is for testing only and might change or be removed in the future. You can still use it today for testing, but it is not meant to be used in a production environment.
 
-We've included an `importer` utility for testing packs on your account. You can run this using the included [import.sh](./import.sh) script.
+We've included an `importer` utility for testing quickstarts on your account. You can run this using the included [import.sh](./import.sh) script.
 
 > Note: The importer spins up a docker container, so you must have docker installed and running for this to function
 
@@ -104,7 +106,7 @@ New Relic hosts and moderates an online forum where customers can interact with 
 
 If you would like to contribute to this project, review [these guidelines](./CONTRIBUTING.md).
 
-We encourage your contributions to improve New Relic One observability packs! Keep in mind that when you submit your pull request, you'll need to sign the CLA via the click-through using CLA-Assistant. You only have to sign the CLA one time per project.
+We encourage your contributions to improve New Relic One quickstarts! Keep in mind that when you submit your pull request, you'll need to sign the CLA via the click-through using CLA-Assistant. You only have to sign the CLA one time per project.
 
 If you have any questions, or to execute our corporate CLA (which is required if your contribution is on behalf of a company), drop us an email at opensource@newrelic.com.
 
@@ -116,4 +118,4 @@ If you believe you have found a security vulnerability in this project or any of
 
 ## License
 
-New Relic One observability packs is licensed under the [Apache 2.0](http://apache.org/licenses/LICENSE-2.0.txt) License.
+New Relic One quickstarts is licensed under the [Apache 2.0](http://apache.org/licenses/LICENSE-2.0.txt) License.

--- a/utils/schemas/alert_config.json
+++ b/utils/schemas/alert_config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Observability Pack Alert Configuration",
-  "description": "Alert configuration schema for Observability Packs",
+  "title": "Quickstart Alert Configuration",
+  "description": "Alert configuration schema for Quickstart",
   "type": "object",
   "properties": {
     "name": {

--- a/utils/schemas/dashboard_config.json
+++ b/utils/schemas/dashboard_config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Observability Pack Dashboard config",
-  "description": "The Dashboard config schema for Observability Packs",
+  "title": "Quickstart Dashboard Configuration",
+  "description": "The Dashboard config schema for quickstarts",
   "type": "object",
   "required": [
     "name",

--- a/utils/schemas/flex_config.json
+++ b/utils/schemas/flex_config.json
@@ -1,11 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Observability Pack Configuration",
-  "description": "A minimal schema definition for Observability Packs",
+  "title": "Quickstart Flex Configuration",
+  "description": "A minimal schema definition for quickstart flex configurations",
   "type": "object",
   "properties": {
     "name": {
-      "description": "The overall name of the Observability Pack",
+      "description": "The overall name of the quickstart",
       "type": "string"
     }
   },

--- a/utils/schemas/flex_integrations.json
+++ b/utils/schemas/flex_integrations.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Observability Pack Synthetics Integrations Config",
-  "description": "Synthetics config for Observability Packs",
+  "title": "Quickstart Flex Integrations Configuration",
+  "description": "Flex integrations config for quickstarts",
   "type": "object",
   "properties": {
     "integrations": {

--- a/utils/schemas/logging_config.json
+++ b/utils/schemas/logging_config.json
@@ -1,11 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Observability Pack Synthetics Configuration",
-  "description": "Logging config for Observability Packs",
+  "title": "Quickstart Logging Configuration",
+  "description": "Logging configuration for quickstarts",
   "type": "object",
   "properties": {
     "name": {
-      "description": "A descriptive name for the Synthetic.",
+      "description": "A descriptive name for the logging configuration.",
       "type": "string"
     }
   },

--- a/utils/schemas/main_config.json
+++ b/utils/schemas/main_config.json
@@ -138,7 +138,7 @@
       "$id": "#/properties/short-description",
       "type": "string",
       "title": "The summary schema",
-      "description": "# Displayed in search results and recommendations. Summarizes a packs functionality.",
+      "description": "# Displayed in search results and recommendations. Summarizes a quickstarts functionality.",
       "minLength": 0,
       "maxLength": 250,
       "default": "",
@@ -169,7 +169,7 @@
       "$id": "#/properties/children",
       "type": "object",
       "title": "The children schema",
-      "description": "Displaying related child packs",
+      "description": "Displaying related child quickstarts",
       "default": {},
       "examples": [
         {

--- a/utils/schemas/synthetic_config.json
+++ b/utils/schemas/synthetic_config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Observability Pack Synthetics Configuration",
-  "description": "Synthetics config for Observability Packs",
+  "title": "Quickstart Synthetics Configuration",
+  "description": "Synthetics configuration for quickstarts",
   "type": "object",
   "properties": {
     "name": {


### PR DESCRIPTION
## Summary

Update documentation to reference quickstarts rather than observability packs.
